### PR TITLE
Updated PHPUnit to version 9.3.0 and bumped the minimum PHP version to 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,24 +12,18 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.2",
         "laminas/laminas-zendframework-bridge": "^1.0",
@@ -41,7 +41,8 @@
         "laminas/laminas-diactoros": "^1.7.1",
         "laminas/laminas-stratigility": "^3.0",
         "malukenho/docheader": "^0.1.6",
-        "phpunit/phpunit": "^7.0.2"
+        "phpunit/phpunit": "^9.3.0",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/AuraRouter/ConfigProviderTest.php
+++ b/test/AuraRouter/ConfigProviderTest.php
@@ -30,7 +30,7 @@ class ConfigProviderTest extends TestCase
     public function testInvocationReturnsArray() : array
     {
         $config = ($this->provider)();
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
 
         return $config;
     }
@@ -41,14 +41,14 @@ class ConfigProviderTest extends TestCase
     public function testReturnedArrayContainsDependencies(array $config) : void
     {
         $this->assertArrayHasKey('dependencies', $config);
-        $this->assertInternalType('array', $config['dependencies']);
+        $this->assertIsArray($config['dependencies']);
 
         $this->assertArrayHasKey('aliases', $config['dependencies']);
-        $this->assertInternalType('array', $config['dependencies']['aliases']);
+        $this->assertIsArray($config['dependencies']['aliases']);
         $this->assertArrayHasKey(RouterInterface::class, $config['dependencies']['aliases']);
 
         $this->assertArrayHasKey('invokables', $config['dependencies']);
-        $this->assertInternalType('array', $config['dependencies']['invokables']);
+        $this->assertIsArray($config['dependencies']['invokables']);
         $this->assertArrayHasKey(AuraRouter::class, $config['dependencies']['invokables']);
     }
 }

--- a/test/AuraRouterTest.php
+++ b/test/AuraRouterTest.php
@@ -20,12 +20,16 @@ use Mezzio\Router\AuraRouter;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use ReflectionClass;
 
 class AuraRouterTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var AuraRouterContainer */
     private $auraRouterContainer;
 
@@ -41,7 +45,7 @@ class AuraRouterTest extends TestCase
     /** @var AuraGenerator */
     private $auraGenerator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->auraRouterContainer = $this->prophesize(AuraRouterContainer::class);
         $this->auraRoute           = $this->prophesize(AuraRoute::class);
@@ -71,7 +75,13 @@ class AuraRouterTest extends TestCase
         $route  = new Route('/foo', $this->getMiddleware(), [RequestMethod::METHOD_GET]);
         $router = $this->getRouter();
         $router->addRoute($route);
-        $this->assertAttributeContains($route, 'routesToInject', $router);
+
+        $reflectionClass = new ReflectionClass($router);
+
+        $property = $reflectionClass->getProperty('routesToInject');
+        $property->setAccessible(true);
+
+        $this->assertContains($route, $property->getValue($router));
 
         return $router;
     }

--- a/test/ImplicitMethodsIntegrationTest.php
+++ b/test/ImplicitMethodsIntegrationTest.php
@@ -13,7 +13,7 @@ namespace MezzioTest\Router;
 use Generator;
 use Mezzio\Router\AuraRouter;
 use Mezzio\Router\RouterInterface;
-use Mezzio\Router\Test\AbstractImplicitMethodsIntegrationTest as RouterIntegrationTest;
+use Mezzio\Router\Test\ImplicitMethodsIntegrationTest as RouterIntegrationTest;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 class ImplicitMethodsIntegrationTest extends RouterIntegrationTest

--- a/test/ImplicitMethodsIntegrationTest.php
+++ b/test/ImplicitMethodsIntegrationTest.php
@@ -14,9 +14,12 @@ use Generator;
 use Mezzio\Router\AuraRouter;
 use Mezzio\Router\RouterInterface;
 use Mezzio\Router\Test\ImplicitMethodsIntegrationTest as RouterIntegrationTest;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ImplicitMethodsIntegrationTest extends RouterIntegrationTest
 {
+    use ProphecyTrait;
+
     public function getRouter() : RouterInterface
     {
         return new AuraRouter();

--- a/test/ImplicitMethodsIntegrationTest.php
+++ b/test/ImplicitMethodsIntegrationTest.php
@@ -13,7 +13,7 @@ namespace MezzioTest\Router;
 use Generator;
 use Mezzio\Router\AuraRouter;
 use Mezzio\Router\RouterInterface;
-use Mezzio\Router\Test\ImplicitMethodsIntegrationTest as RouterIntegrationTest;
+use Mezzio\Router\Test\AbstractImplicitMethodsIntegrationTest as RouterIntegrationTest;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 class ImplicitMethodsIntegrationTest extends RouterIntegrationTest


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Updated PHPUnit to version 9.3.0 and bumped the minimum PHP version to 7.3. This is in preparation of a pull request to add support for PHP 8.0.