### PR TITLE
PHP 8.0 compatiblity and dependency upgrades.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ matrix:
     - php: 7.4
       env:
         - DEPS=latest
+    - php: 8.0
+        env:
+          - DEPS=lowest
+    - php: 8.0
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
       env:
         - DEPS=latest
     - php: 8.0
-        env:
-          - DEPS=lowest
+      env:
+        - DEPS=lowest
     - php: 8.0
       env:
         - DEPS=latest

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.3",
         "aura/router": "^3.1",
-        "fig/http-message-util": "^1.1.2",
+        "fig/http-message-util": "^1.1.5",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.0",
         "psr/http-message": "^1.0.1"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-zendframework-bridge": "^1.1.0",
-        "mezzio/mezzio-router": "^3.0",
+        "mezzio/mezzio-router": "^3.2.0",
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php": "^7.3",
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.5",
-        "laminas/laminas-zendframework-bridge": "^1.0",
+        "laminas/laminas-zendframework-bridge": "^1.1.0",
         "mezzio/mezzio-router": "^3.0",
         "psr/http-message": "^1.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-zendframework-bridge": "^1.1.0",
-        "mezzio/mezzio-router": "^3.2.0",
+        "mezzio/mezzio-router": "^3.2.1",
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^2.5.0",
-        "laminas/laminas-stratigility": "^3.0",
+        "laminas/laminas-stratigility": "^3.3.0",
         "malukenho/docheader": "^0.1.6",
         "phpunit/phpunit": "^9.3.0",
         "phpspec/prophecy-phpunit": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-diactoros": "^1.7.1",
+        "laminas/laminas-diactoros": "^2.5.0",
         "laminas/laminas-stratigility": "^3.0",
         "malukenho/docheader": "^0.1.6",
         "phpunit/phpunit": "^9.3.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3||~8.0.0",
         "aura/router": "^3.1",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-zendframework-bridge": "^1.1.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^2.5.0",
         "laminas/laminas-stratigility": "^3.3.0",
-        "malukenho/docheader": "^0.1.6",
+        "malukenho/docheader": "^0.1.8",
         "phpunit/phpunit": "^9.3.0",
         "phpspec/prophecy-phpunit": "^2.0"
     },

--- a/src/AuraRouter.php
+++ b/src/AuraRouter.php
@@ -65,7 +65,7 @@ class AuraRouter implements RouterInterface
      * an instance. If you need to customize the Aura.Router instance in any
      * way, you MUST inject it yourself.
      */
-    public function __construct(Router $router = null)
+    public function __construct(?Router $router = null)
     {
         if (null === $router) {
             $router = $this->createRouter();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This pull requests aims to make mezzio-aurarouter PHP 8.0 compatible. I've bumped the dependencies to the **lowest** version that supports PHP 7.3 up until 8.0.

Fixes #2